### PR TITLE
CI Pipeline

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,19 @@
+name: Continuous Integration
+
+on:
+  push:
+  workflow-dispatch:
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.18'
+
+      - name: Test
+        run: make test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,10 @@ name: Continuous Integration
 
 on:
   push:
-  workflow-dispatch:
+    branches: main
+
+  pull_request:
+    branches: main
 
 jobs:
   build-test:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+.PHONY: test
+test:
+	@echo "\n 🛠️  Running unit tests..."
+	go test ./...
+
+.PHONY: build
+build:
+	@echo "\n 🔧  Building binary..."
+	GOOS=darwin GOARCH=amd64 go build -a -o bin/ktop cmd/ktop.go


### PR DESCRIPTION
### What this PR does?
- Adds a basic CI pipeline that runs the unit tests for the `ktop` CLI tool
- Provides a `make build` command to build the binary in the future